### PR TITLE
feat: add HMR support for schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "@graphql-codegen/typescript-resolvers": "^2.7.6",
     "@graphql-tools/graphql-file-loader": "^7.5.9",
     "@graphql-tools/load": "^7.8.4",
-    "@nuxt/kit": "^3.0.0-rc.13"
+    "@nuxt/kit": "^3.0.0-rc.13",
+    "multimatch": "^6.0.0"
   },
   "peerDependencies": {
     "graphql": "^16.6.0"

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,5 +1,9 @@
 <template>
-  <div>Nuxt module playground!</div>
+  <h1>GraphQL Playground</h1>
+  <h2>Schema:</h2>
+  <pre>{{ schema }}</pre>
 </template>
 
-<script setup></script>
+<script setup>
+import { schema } from '#graphql/schema'
+</script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ specifiers:
   eslint-config-prettier: ^8.5.0
   eslint-plugin-unused-imports: ^2.0.0
   graphql: ^16.6.0
+  multimatch: ^6.0.0
   nuxt: ^3.0.0-rc.13
   prettier: ^2.7.1
   standard-version: ^9.5.0
@@ -37,6 +38,7 @@ dependencies:
   '@graphql-tools/graphql-file-loader': 7.5.9_graphql@16.6.0
   '@graphql-tools/load': 7.8.4_graphql@16.6.0
   '@nuxt/kit': 3.0.0-rc.13
+  multimatch: 6.0.0
 
 devDependencies:
   '@apollo/server': 4.1.1_graphql@16.6.0
@@ -1760,6 +1762,10 @@ packages:
     resolution: {integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==}
     dev: true
 
+  /@types/minimatch/3.0.5:
+    resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
+    dev: false
+
   /@types/minimist/1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
     dev: true
@@ -2285,6 +2291,11 @@ packages:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: true
 
+  /array-differ/4.0.0:
+    resolution: {integrity: sha512-Q6VPTLMsmXZ47ENG3V+wQyZS1ZxXMxFyYzA+Z/GMrJ6yIutAIEf9wTyroTzmGjNfox9/h3GdGBCVh43GVFx4Uw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
+
   /array-flatten/1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
     dev: true
@@ -2307,6 +2318,11 @@ packages:
   /array-union/2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  /array-union/3.0.1:
+    resolution: {integrity: sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==}
+    engines: {node: '>=12'}
+    dev: false
 
   /array.prototype.flat/1.3.1:
     resolution: {integrity: sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==}
@@ -5960,6 +5976,16 @@ packages:
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
+
+  /multimatch/6.0.0:
+    resolution: {integrity: sha512-I7tSVxHGPlmPN/enE3mS1aOSo6bWBfls+3HmuEeCUBCE7gWnm3cBXCBkpurzFjVRwC6Kld8lLaZ1Iv5vOcjvcQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      '@types/minimatch': 3.0.5
+      array-differ: 4.0.0
+      array-union: 3.0.1
+      minimatch: 3.1.2
+    dev: false
 
   /mute-stream/0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,12 +1,21 @@
-import { addTemplate, createResolver, defineNuxtModule } from '@nuxt/kit'
+import {
+  addTemplate,
+  createResolver,
+  defineNuxtModule,
+  updateTemplates,
+  useLogger,
+} from '@nuxt/kit'
 import { relative } from 'path'
 import { CodeGenConfig, createResolverTypeDefs } from './codegen'
 import { createSchemaImport } from './schema-loader'
+import multimatch from 'multimatch'
 
 export interface ModuleOptions {
   schema: string | string[]
   codegen?: CodeGenConfig
 }
+
+const logger = useLogger('graphql/server')
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {
@@ -24,14 +33,15 @@ export default defineNuxtModule<ModuleOptions>({
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const { resolve } = createResolver(import.meta.url)
 
-    nuxt.hook('nitro:config', async (nitroConfig) => {
-      // Register #graphql/schema virtual module
-      nitroConfig.virtual = nitroConfig.virtual || {}
-      nitroConfig.virtual['#' + 'graphql/schema'] = await createSchemaImport(
-        options.schema,
-        nitroConfig.rootDir
-      )
+    // Register #graphql/schema virtual module
+    const { dst: schemaPath } = addTemplate({
+      filename: 'graphql-schema.mjs',
+      getContents: () =>
+        createSchemaImport(options.schema, nuxt.options.rootDir),
+      write: true,
     })
+    logger.info(`GraphQL schema registered at ${schemaPath}`)
+    nuxt.options.alias['#' + 'graphql/schema'] = schemaPath
 
     // Create types in build dir
     const { dst: typeDefPath } = addTemplate({
@@ -40,12 +50,14 @@ export default defineNuxtModule<ModuleOptions>({
     })
     const { dst: resolverTypeDefPath } = addTemplate({
       filename: 'types/graphql-server-resolver.d.ts',
-      getContents: () =>
-        createResolverTypeDefs(
+      getContents: () => {
+        logger.debug('Generating graphql-server-resolver.d.ts')
+        return createResolverTypeDefs(
           options.schema,
           options.codegen ?? {},
           nuxt.options.rootDir
-        ),
+        )
+      },
     })
 
     // Add types to `nuxt.d.ts`
@@ -60,5 +72,30 @@ export default defineNuxtModule<ModuleOptions>({
         relative(nuxt.options.rootDir, resolverTypeDefPath),
       ]
     })
+
+    // HMR support for schema files
+    if (nuxt.options.dev) {
+      nuxt.hook('vite:serverCreated', (viteServer, ctx) => {
+        //if (ctx.isServer) {
+        //}
+        nuxt.hook('builder:watch', async (event, path) => {
+          if (multimatch(path, options.schema)) {
+            logger.debug('schema changed', path)
+            //logger.info(viteServer?.moduleGraph)
+            //const module = await viteServer?.moduleGraph.getModuleByUrl("#graphql/schema")
+            const module = viteServer?.moduleGraph.getModuleById(schemaPath)
+            logger.info('module', module)
+            if (module) {
+              await viteServer?.reloadModule(module)
+            }
+            await updateTemplates({
+              filter: (template) =>
+                template.filename.startsWith('types/graphql-server') ||
+                template.filename === 'graphql-schema.mjs',
+            })
+          }
+        })
+      })
+    }
   },
 })


### PR DESCRIPTION
Fixes #3.

Server side HMR is currently blocked by https://github.com/nuxt/framework/issues/8720. So we call directly the nitro dev:reload hook, which triggers a complete reload of the server https://github.com/unjs/nitro/blob/7f430d7e0b57fd1713b704ded0d2af895593063a/src/dev/server.ts#L100