### PR TITLE
chore: fix deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "scripts": {
-    "prepare": "nuxt-module-build --stub && nuxi prepare playground",
+    "postinstall": "nuxt-module-build --stub && nuxi prepare playground",
     "prepack": "nuxt-module-build && cp src/graphql-server.d.ts dist",
     "build": "pnpm prepack",
     "dev": "nuxi dev playground",


### PR DESCRIPTION
Fixes #34.

Prepare is not the correct hook as discussed in https://github.com/nuxt/starter/pull/156.