### PR TITLE
fix: hmr schema watcher had an always truthy conditional check

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -77,7 +77,7 @@ export default defineNuxtModule<ModuleOptions>({
     })
     const resolverTypesTemplateName = 'types/graphql-server-resolver.d.ts'
     const { dst: resolverTypeDefPath } = addTemplate({
-      filename: 'types/
+      filename: resolverTypesTemplateName,
       getContents: () => {
         logger.debug(`Generating ${resolverTypesTemplateName}`)
         return createResolverTypeDefs(

--- a/src/module.ts
+++ b/src/module.ts
@@ -105,7 +105,12 @@ export default defineNuxtModule<ModuleOptions>({
     if (nuxt.options.dev) {
       nuxt.hook('nitro:build:before', (nitro) => {
         nuxt.hook('builder:watch', async (event, path) => {
-          if (multimatch(path, options.schema).length > 0) {
+           const schema = Array.isArray(options.schema)
+            ? options.schema.map(pattern =>
+                resolve(nuxt.options.rootDir, pattern),
+              )
+            : resolve(nuxt.options.rootDir, options.schema)
+          if (multimatch(path, schema).length > 0) {
             logger.debug('Schema changed', path)
 
             // Update templates

--- a/src/module.ts
+++ b/src/module.ts
@@ -20,6 +20,8 @@ export interface ModuleOptions {
 }
 
 const logger = useLogger('graphql/server')
+// Activate this to see debug logs if you run `pnpm dev --loglevel verbose`
+// logger.level = 5
 
 function setAlias(nuxt: Nuxt, alias: string, path: string) {
   // workaround for https://github.com/nuxt/nuxt/issues/19453
@@ -63,8 +65,10 @@ export default defineNuxtModule<ModuleOptions>({
     const schemaPathTemplateName = 'graphql-schema.mjs'
     const { dst: schemaPath } = addTemplate({
       filename: schemaPathTemplateName,
-      getContents: () =>
-        createSchemaImport(options.schema, nuxt.options.rootDir),
+      getContents: () => {
+        logger.debug(`Generating ${schemaPathTemplateName}`)
+        return createSchemaImport(options.schema, nuxt.options.rootDir)
+      },
       write: true,
     })
     logger.debug(`GraphQL schema registered at ${schemaPath}`)
@@ -105,19 +109,22 @@ export default defineNuxtModule<ModuleOptions>({
     if (nuxt.options.dev) {
       nuxt.hook('nitro:build:before', (nitro) => {
         nuxt.hook('builder:watch', async (event, path) => {
-           const schema = Array.isArray(options.schema)
-            ? options.schema.map(pattern =>
-                resolve(nuxt.options.rootDir, pattern),
+          logger.debug('File changed', path)
+          // Depending on the nuxt version, path is either absolute or relative
+          const absolutePath = resolve(nuxt.options.srcDir, path)
+          const schema = Array.isArray(options.schema)
+            ? options.schema.map((pattern) =>
+                resolve(nuxt.options.srcDir, pattern),
               )
-            : resolve(nuxt.options.rootDir, options.schema)
-          if (multimatch(path, schema).length > 0) {
-            logger.debug('Schema changed', path)
+            : resolve(nuxt.options.srcDir, options.schema)
+          if (multimatch(absolutePath, schema).length > 0) {
+            logger.debug('Schema changed', absolutePath)
 
             // Update templates
             await updateTemplates({
               filter: (template) =>
                 template.filename === resolverTypesTemplateName ||
-                template.filename === schemaPathTemplateName
+                template.filename === schemaPathTemplateName,
             })
 
             // Reload nitro dev server

--- a/src/module.ts
+++ b/src/module.ts
@@ -60,8 +60,9 @@ export default defineNuxtModule<ModuleOptions>({
     const { resolve } = createResolver(import.meta.url)
 
     // Register #graphql/schema virtual module
+    const schemaPathTemplateName = 'graphql-schema.mjs'
     const { dst: schemaPath } = addTemplate({
-      filename: 'graphql-schema.mjs',
+      filename: schemaPathTemplateName,
       getContents: () =>
         createSchemaImport(options.schema, nuxt.options.rootDir),
       write: true,
@@ -74,10 +75,11 @@ export default defineNuxtModule<ModuleOptions>({
       filename: 'types/graphql-server.d.ts',
       src: resolve('graphql-server.d.ts'),
     })
+    const resolverTypesTemplateName = 'types/graphql-server-resolver.d.ts'
     const { dst: resolverTypeDefPath } = addTemplate({
-      filename: 'types/graphql-server-resolver.d.ts',
+      filename: 'types/
       getContents: () => {
-        logger.debug('Generating graphql-server-resolver.d.ts')
+        logger.debug(`Generating ${resolverTypesTemplateName}`)
         return createResolverTypeDefs(
           options.schema,
           options.codegen ?? {},
@@ -109,8 +111,8 @@ export default defineNuxtModule<ModuleOptions>({
             // Update templates
             await updateTemplates({
               filter: (template) =>
-                template.filename.startsWith('types/graphql-server') ||
-                template.filename === 'graphql-schema.mjs',
+                template.filename === resolverTypesTemplateName ||
+                template.filename === schemaPathTemplateName
             })
 
             // Reload nitro dev server

--- a/src/module.ts
+++ b/src/module.ts
@@ -103,7 +103,7 @@ export default defineNuxtModule<ModuleOptions>({
     if (nuxt.options.dev) {
       nuxt.hook('nitro:build:before', (nitro) => {
         nuxt.hook('builder:watch', async (event, path) => {
-          if (multimatch(path, options.schema)) {
+          if (multimatch(path, options.schema).length > 0) {
             logger.debug('Schema changed', path)
 
             // Update templates


### PR DESCRIPTION
Multimatch always returns an array, even an empty one when there's no match, which is a truthy value. This meant that templates were always updated even if it's not schema files that were changed.

Another significant change is resolving schema as path patterns. The `path` argument from the watch hook is absolute, so an unresolved schema that starts with ./ would have always been false. This would not have been found because of the first bug with the matcher condition.

I'm not sure, but it might help with https://github.com/tobiasdiez/nuxt-graphql-server/issues/57